### PR TITLE
Add dark themed link hub page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # LinksWebsite
 
-This is a simple page inspired by Linktree for collecting all of your social media links in one place.
+A simple dark-themed "link hub" page inspired by Linktree. Replace the placeholder links and images with your own to create a personal profile card.
 
 ## Usage
-
-1. Edit `index.html` to replace the sample links with your own profiles.
-2. Replace the profile image URL inside `index.html` with your own photo.
-3. Open `index.html` in a browser to view your page.
-4. Customize the style by editing `style.css`.
+1. Edit `index.html` with your profile name, image, and URLs.
+2. Open `index.html` in a browser to view the page.
+3. Tweak colors and layout in `style.css` if desired.

--- a/index.html
+++ b/index.html
@@ -3,24 +3,70 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>My Links</title>
+    <title>Koneko Links</title>
+    <!-- Google font -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+    <!-- Local stylesheet -->
     <link rel="stylesheet" href="style.css">
+    <!-- Font Awesome icons -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha512-NInh5pwvDUc0lPChq96IBmTyI9MT9VKXf9Wcw8BwW94E2wCvgp+D+B9cbapK08UpnvDdxbJTDzDZhVrCkd0+xg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 </head>
 <body>
-    <div class="container">
-        <div class="profile">
-            <img src="https://via.placeholder.com/150" alt="Profile picture">
-            <h1>My Links</h1>
+    <main class="card">
+        <!-- Profile section -->
+        <header class="profile">
+            <img src="https://via.placeholder.com/150" alt="Profile image">
+            <h1>Koneko</h1>
+        </header>
+        <!-- Social links -->
+        <nav>
+            <ul class="links">
+                <li>
+                    <a href="#" target="_blank">
+                        <span class="icon"><i class="fab fa-github"></i></span>
+                        <span class="label">GitHub</span>
+                        <span class="actions"><i class="fas fa-ellipsis-v"></i></span>
+                    </a>
+                </li>
+                <li>
+                    <a href="#" target="_blank">
+                        <span class="icon"><i class="fab fa-tiktok"></i></span>
+                        <span class="label">TikTok</span>
+                        <span class="actions"><i class="fas fa-ellipsis-v"></i></span>
+                    </a>
+                </li>
+                <li>
+                    <a href="#" target="_blank">
+                        <span class="icon"><i class="fab fa-twitch"></i></span>
+                        <span class="label">Twitch</span>
+                        <span class="actions"><i class="fas fa-ellipsis-v"></i></span>
+                    </a>
+                </li>
+                <li>
+                    <a href="#" target="_blank">
+                        <span class="icon"><i class="fab fa-twitter"></i></span>
+                        <span class="label">Twitter</span>
+                        <span class="actions"><i class="fas fa-ellipsis-v"></i></span>
+                    </a>
+                </li>
+                <li>
+                    <a href="#" target="_blank">
+                        <span class="icon"><i class="fa fa-gift"></i></span>
+                        <span class="label">Throne</span>
+                        <span class="actions"><i class="fas fa-ellipsis-v"></i></span>
+                    </a>
+                </li>
+            </ul>
+        </nav>
+        <!-- Call to action -->
+        <div class="cta">
+            <a class="support" href="#">Support Me</a>
+            <div class="footer-links">
+                <a href="#">Privacy</a>
+                <a href="#">Report</a>
+            </div>
         </div>
-        <ul class="links">
-            <li><a href="https://instagram.com/yourusername" target="_blank"><i class="fab fa-instagram"></i> Instagram</a></li>
-            <li><a href="https://twitter.com/yourusername" target="_blank"><i class="fab fa-twitter"></i> Twitter</a></li>
-            <li><a href="https://github.com/yourusername" target="_blank"><i class="fab fa-github"></i> GitHub</a></li>
-            <li><a href="https://linkedin.com/in/yourusername" target="_blank"><i class="fab fa-linkedin"></i> LinkedIn</a></li>
-        </ul>
-    </div>
+    </main>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,56 +1,106 @@
+/* Base styles */
 body {
     font-family: 'Roboto', sans-serif;
-    background: #f1f1f1;
-    color: #333;
-    text-align: center;
+    background: #000; /* dark background */
+    color: #fff;
     margin: 0;
     padding: 0;
     min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
-.container {
-    padding-top: 10vh;
+/* Main card container */
+.card {
     width: 90%;
     max-width: 480px;
-    margin: 0 auto;
+    text-align: center;
 }
 
+/* Profile image and name */
 .profile img {
     width: 120px;
     height: 120px;
     border-radius: 50%;
-    border: 4px solid #fff;
+    object-fit: cover;
     margin-bottom: 10px;
 }
 
 .profile h1 {
-    margin: 0 0 20px 0;
+    margin: 0 0 20px;
     font-size: 2em;
+    font-weight: 700;
 }
 
+/* Links list */
 .links {
     list-style: none;
     padding: 0;
     margin: 0;
 }
 
-.links li {
-    margin: 10px 0;
+.links li + li {
+    margin-top: 15px;
 }
 
 .links a {
-    display: block;
-    width: 100%;
-    color: #333;
-    font-size: 1.2em;
-    text-decoration: none;
-    background-color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: #1a1a1a;
+    color: #fff;
     padding: 15px 20px;
+    text-decoration: none;
     border-radius: 12px;
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-    transition: background 0.2s ease-in-out;
+    transition: transform 0.2s ease, background 0.2s ease;
 }
 
 .links a:hover {
-    background-color: #f2f2f2;
+    background: #2a2a2a;
+    transform: scale(1.03);
+}
+
+.links .icon {
+    margin-right: 10px;
+}
+
+.links .label {
+    flex: 1;
+    text-align: left;
+}
+
+/* Call to action section */
+.cta {
+    margin-top: 30px;
+}
+
+.support {
+    display: inline-block;
+    padding: 12px 24px;
+    background: #444;
+    color: #fff;
+    border-radius: 20px;
+    text-decoration: none;
+    transition: background 0.2s ease;
+}
+
+.support:hover {
+    background: #555;
+}
+
+.footer-links {
+    margin-top: 10px;
+    font-size: 0.8em;
+    color: #aaa;
+}
+
+.footer-links a {
+    color: #999;
+    margin: 0 5px;
+    text-decoration: none;
+}
+
+.footer-links a:hover {
+    text-decoration: underline;
 }


### PR DESCRIPTION
## Summary
- redesign link hub with a centered dark theme
- style links with icons and hover effects
- add support button with privacy/report links
- update README instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687aaa59051c832a8a3d3a6a2e938ffb