### PR TITLE
Fix social icon sizing

### DIFF
--- a/style.css
+++ b/style.css
@@ -51,8 +51,9 @@ body {
 
 
 .social-icons img {
-    width: 36px;
-    height: 36px;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
 }
 
 


### PR DESCRIPTION
## Summary
- fix alignment of header icons by containing them within their parent link

## Testing
- `identify github-mark-white.png`
- `identify glitch_flat_white.png`
- `identify logo-white.png`
- `identify 'Throne Icon - Single (Light).png'`

------
https://chatgpt.com/codex/tasks/task_e_687ba583db0c832aafdeb375282a14e2